### PR TITLE
STYLE: Use Macro for Function Deletion

### DIFF
--- a/include/itkSplitComponentsImageFilter.h
+++ b/include/itkSplitComponentsImageFilter.h
@@ -93,8 +93,7 @@ protected:
   virtual void ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType threadId );
 
 private:
-  SplitComponentsImageFilter( const Self& ); // purposely not implemented
-  void operator=( const Self& ); // purposely not implemented
+  ITK_DISALLOW_COPY_AND_ASSIGN(SplitComponentsImageFilter);
 
   ComponentsMaskType m_ComponentsMask;
 };


### PR DESCRIPTION
Use ITK_DISALLOW_COPY_AND_ASSIGN macro to delete copy and assignment constructors which uses c++11's rigorous function deletion on compilers that support it.
