### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkSplitComponentsImageFilter.h
+++ b/include/itkSplitComponentsImageFilter.h
@@ -49,6 +49,8 @@ class SplitComponentsImageFilter:
   public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SplitComponentsImageFilter);
+
   /** ImageDimension enumeration. */
   static constexpr unsigned int ImageDimension = TInputImage::ImageDimension;
   /** Components enumeration. */
@@ -91,8 +93,6 @@ protected:
   void ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType threadId ) override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SplitComponentsImageFilter);
-
   ComponentsMaskType m_ComponentsMask;
 };
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.