### PR TITLE
BUG: Fix test errors steming from the new multi-threading mechanism.

### DIFF
--- a/include/itkSplitComponentsImageFilter.h
+++ b/include/itkSplitComponentsImageFilter.h
@@ -90,7 +90,7 @@ protected:
   /** Do not allocate outputs that we will not populate. */
   void AllocateOutputs() override;
 
-  void ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType threadId ) override;
+  void DynamicThreadedGenerateData( const OutputRegionType& outputRegion ) override;
 
 private:
   ComponentsMaskType m_ComponentsMask;

--- a/include/itkSplitComponentsImageFilter.hxx
+++ b/include/itkSplitComponentsImageFilter.hxx
@@ -28,7 +28,8 @@ namespace itk
 
 template< class TInputImage, class TOutputImage, unsigned int TComponents >
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
-::SplitComponentsImageFilter()
+::SplitComponentsImageFilter() :
+  m_DynamicMultiThreading( true )
 {
   this->m_ComponentsMask.Fill( true );
 
@@ -75,7 +76,7 @@ SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 template< class TInputImage, class TOutputImage, unsigned int TComponents >
 void
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
-::ThreadedGenerateData( const OutputRegionType& outputRegion, ThreadIdType itkNotUsed(threadId) )
+::DynamicThreadedGenerateData( const OutputRegionType& outputRegion )
 {
   typename InputImageType::ConstPointer input = this->GetInput();
   ProcessObject::DataObjectPointerArray outputs = this->GetOutputs();


### PR DESCRIPTION
Fix errors steming from the use of the new `itk::PoolMultiThreader`
class for multi-threading.

The errors stemmed when this gerrit topic got merged:
http://review.source.kitware.com/#/c/23175/

And were later related to the following gerrit-topic:
http://review.source.kitware.com/#/c/23434/

The solution adopted in this patch set was based on the proposal in:
http://review.source.kitware.com/#/c/23439/