### PR TITLE
BUG: Use boolean macro call to initialize dynamic multi-threading ivar.

### DIFF
--- a/include/itkSplitComponentsImageFilter.hxx
+++ b/include/itkSplitComponentsImageFilter.hxx
@@ -28,8 +28,7 @@ namespace itk
 
 template< class TInputImage, class TOutputImage, unsigned int TComponents >
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
-::SplitComponentsImageFilter() :
-  m_DynamicMultiThreading( true )
+::SplitComponentsImageFilter()
 {
   this->m_ComponentsMask.Fill( true );
 
@@ -40,6 +39,8 @@ SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
     {
     this->SetNthOutput( i, this->MakeOutput( i ) );
     }
+
+  this->DynamicMultiThreadingOn();
 }
 
 


### PR DESCRIPTION
Prefer the boolean macro function call to initialize the dynamic
multi-threading ivar for the reasons stated here:
http://review.source.kitware.com/#/c/23434/