### PR TITLE
BUG: Allow for building outside ITK.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,2 +1,12 @@
-project( SplitComponents )
-itk_module_impl()
+cmake_minimum_required(VERSION 3.10.2)
+project(SplitComponents)
+
+set(SplitComponents_LIBRARIES SplitComponents)
+
+if(NOT ITK_SOURCE_DIR)
+  find_package(ITK REQUIRED)
+  list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
+  include(ITKModuleExternal)
+else()
+  itk_module_impl()
+endif()


### PR DESCRIPTION
Re-work the `CMakeLists.txt` file so that the module can be built
outside ITK, following:
https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/commit/b4d185d6cdda423f5c344a3ad3d40341db06d401