### PR TITLE
STYLE: Use "typename" for template parameters.

### DIFF
--- a/include/itkSplitComponentsImageFilter.h
+++ b/include/itkSplitComponentsImageFilter.h
@@ -44,7 +44,7 @@ namespace itk
  * \sa DiffusionTensor3D
  * \sa NthElementImageAdaptor
  */
-template< class TInputImage, class TOutputImage, unsigned int TComponents = TInputImage::ImageDimension >
+template< typename TInputImage, typename TOutputImage, unsigned int TComponents = TInputImage::ImageDimension >
 class ITK_TEMPLATE_EXPORT SplitComponentsImageFilter:
   public ImageToImageFilter< TInputImage, TOutputImage >
 {

--- a/include/itkSplitComponentsImageFilter.hxx
+++ b/include/itkSplitComponentsImageFilter.hxx
@@ -26,7 +26,7 @@
 namespace itk
 {
 
-template< class TInputImage, class TOutputImage, unsigned int TComponents >
+template< typename TInputImage, typename TOutputImage, unsigned int TComponents >
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 ::SplitComponentsImageFilter()
 {
@@ -44,7 +44,7 @@ SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 }
 
 
-template< class TInputImage, class TOutputImage, unsigned int TComponents >
+template< typename TInputImage, typename TOutputImage, unsigned int TComponents >
 void
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 ::AllocateOutputs()
@@ -74,7 +74,7 @@ SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 }
 
 
-template< class TInputImage, class TOutputImage, unsigned int TComponents >
+template< typename TInputImage, typename TOutputImage, unsigned int TComponents >
 void
 SplitComponentsImageFilter< TInputImage, TOutputImage, TComponents >
 ::DynamicThreadedGenerateData( const OutputRegionType& outputRegion )


### PR DESCRIPTION
As discussed in:
http://review.source.kitware.com/#/c/12655/

the use of the template keyword "class" was substituted by "typename" in
the toolkit for the reasons stated in that topic.