### PR TITLE
DOC: Re-use `README.rst` info in `itk-module.cmake`.

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,8 +1,14 @@
-set( DOCUMENTATION "This module contains filter called
-itk::SplitComponentsImageFilter.  This filter generates component images from an
-itk::Image of, for example, itk::Vector, itk::CovariantVector, or
-itk::SymmetricSecondRankTensor." )
+# the top-level README is used for describing this module, just
+# re-used it for documentation here
+get_filename_component(MY_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+file(READ "${MY_CURRENT_DIR}/README.rst" DOCUMENTATION)
 
+# itk_module() defines the module dependencies in SplitComponents
+# The testing module in SplitComponents depends on ITKTestKernel
+# By convention those modules outside of ITK are not prefixed with
+# ITK.
+
+# define the dependencies of the include module and the tests
 itk_module(SplitComponents
   DEPENDS
     ITKCommon


### PR DESCRIPTION
Re-use `README.rst` info in `itk-module.cmake`.

Helps avoiding duplications/diverging versions of the documentation.