### PR TITLE
STYLE: Prefer = default to explicitly trivial implementations

### DIFF
--- a/include/itkSplitComponentsImageFilter.h
+++ b/include/itkSplitComponentsImageFilter.h
@@ -85,7 +85,7 @@ public:
 
 protected:
   SplitComponentsImageFilter();
-  ~SplitComponentsImageFilter() override {}
+  ~SplitComponentsImageFilter() override = default;
 
   /** Do not allocate outputs that we will not populate. */
   void AllocateOutputs() override;


### PR DESCRIPTION
This check replaces default bodies of special member functions with
`= default;`. The explicitly defaulted function declarations enable more
opportunities in optimization, because the compiler might treat
explicitly defaulted functions as trivial.

Additionally, the C++11 use of `= default` more clearly expresses the
intent for the special member functions.