### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkSplitComponentsImageFilter.hxx
+++ b/include/itkSplitComponentsImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkSplitComponentsImageFilter_hxx
 #define itkSplitComponentsImageFilter_hxx
 
-#include "itkSplitComponentsImageFilter.h"
 
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

