### PR TITLE
ENH: Support building manylinux2014 wheels

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -158,7 +158,11 @@ jobs:
     - name: 'Build 🐍 Python 📦 package'
       run: |
         export ITK_PACKAGE_VERSION=${{ env.itk-wheel-tag }}
-        ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }}
+        for tarball in "" "-manylinux2014"; do
+          rm -rf ITKPythonPackage
+          export TARBALL_SPECIALIZATION=${tarball}
+          ./dockcross-manylinux-download-cache-and-build-module-wheels.sh cp${{ matrix.python-version }}
+        done
 
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
In addition to manylinux_2_28 wheels.

The manylinux2014 wheels support systems with glibc down to 2.17, e.g.
Ubuntu 20.04. They also use the older C++ ABI.

manylinux_2_28 supports systems with glibc down to 2.28. They use the
newer C++ ABI (required for compatibilty with other packages, e.g.
PyTorch, in 3D Slicer) and the compiler supports up to C++17.