### PR TITLE
ENH: Bump macos version in CI

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -12,13 +12,13 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
         include:
           - os: ubuntu-20.04
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             cmake-build-type: "Release"
-          - os: macos-10.15
+          - os: macos-11
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -70,7 +70,7 @@ jobs:
         path: dist
 
   build-macos-python-packages:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       max-parallel: 2
 
@@ -79,6 +79,7 @@ jobs:
 
     - name: 'Specific XCode version'
       run: |
+        ls "/Applications"
         sudo xcode-select -s "/Applications/Xcode_11.7.app"
 
     - name: Get specific version of CMake, Ninja
@@ -92,7 +93,7 @@ jobs:
     - name: 'Build 🐍 Python 📦 package'
       run: |
         export ITK_PACKAGE_VERSION=${{ env.itk-wheel-tag }}
-        export MACOSX_DEPLOYMENT_TARGET=10.9
+        export MACOSX_DEPLOYMENT_TARGET=10.11
         ./macpython-download-cache-and-build-module-wheels.sh
 
     - name: Publish Python package as GitHub Artifact


### PR DESCRIPTION
See https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/