### PR TITLE
ENH: Build only required ITK modules for testing

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -5,6 +5,8 @@ on: [push,pull_request]
 jobs:
   cxx-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@d4a5ce4f219b66b78269a15392e15c95f90e7e00
+    with:
+      itk-cmake-options: '-DITK_BUILD_DEFAULT_MODULES:BOOL=OFF -DITKGroup_Core:BOOL=ON'
 
   python-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@d4a5ce4f219b66b78269a15392e15c95f90e7e00


### PR DESCRIPTION
Reduces ITK build step in cxx workflow from approximately 21 mins to 17 mins on macOS, 18 mins to 11 mins on Windows, and 11 mins to 7 mins on Linux.

This is an optimization that will help speed up iteration for workflow fixes tested against ITKSplitComponents.