### PR TITLE
BUG: Fix test variable names for remote module

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,13 +1,12 @@
 itk_module_test()
-set( ITKSplitComponentsTests
+set( SplitComponentsTests
   itkSplitComponentsImageFilterTest.cxx
   )
-CreateTestDriver( ITKSplitComponents "${ITKSplitComponents-Test_LIBRARIES}" "${ITKSplitComponentsTests}" )
+CreateTestDriver( SplitComponents "${SplitComponents-Test_LIBRARIES}" "${SplitComponentsTests}" )
 
-set( TEMP ${ITK_TEST_OUTPUT_DIR} )
 
 itk_add_test(NAME itkSplitComponentsImageFilterTest
-  COMMAND ITKSplitComponentsTestDriver
+  COMMAND SplitComponentsTestDriver
   --compare
     DATA{Baseline/itkSplitComponentsImageFilterTestBaseline0.mha}
     itkSplitComponentsImageFilterTestOutput0.mha


### PR DESCRIPTION
Remove ITK prefix from variable names as it's for internal ITK modules.

- Use correct `SplitComponents-Test_LIBRARIES` instead of `ITKSplitComponents-Test_LIBRARIES`
- Update test driver name from `ITKSplitComponentsTestDriver` to `SplitComponentsTestDriver`
- Clean up related variables accordingly