### PR TITLE
ENH: Convert ExternalData .md5 tags to .cid (IPFS content IDs)

### DIFF
--- a/test/Baseline/itkSplitComponentsImageFilterTestBaseline0.mha.cid
+++ b/test/Baseline/itkSplitComponentsImageFilterTestBaseline0.mha.cid
@@ -1,0 +1,1 @@
+bafkreiamxu2cy6vfjc6t5fsvcdaeqn36chmnpnimtcnlxnmy5z3tjmaghe

--- a/test/Baseline/itkSplitComponentsImageFilterTestBaseline0.mha.md5
+++ b/test/Baseline/itkSplitComponentsImageFilterTestBaseline0.mha.md5
@@ -1,1 +1,0 @@
-a3519cb25bb2bfeda9d976da2f9707cd

--- a/test/Baseline/itkSplitComponentsImageFilterTestBaseline1.mha.cid
+++ b/test/Baseline/itkSplitComponentsImageFilterTestBaseline1.mha.cid
@@ -1,0 +1,1 @@
+bafkreif3tkgmecbfvioj3ijohqdre77nfzf6foimlcxlscr5ud54qsooqe

--- a/test/Baseline/itkSplitComponentsImageFilterTestBaseline1.mha.md5
+++ b/test/Baseline/itkSplitComponentsImageFilterTestBaseline1.mha.md5
@@ -1,1 +1,0 @@
-b53699740d1fafd85bd66a9df0c23b5a


### PR DESCRIPTION
Migrate ExternalData content-link stubs from legacy md5/sha512 hashes to IPFS .cid tags, aligning this remote module with the ITK-wide CID migration.

<details>
<summary>Verification</summary>

- Based on current `origin/main`.
- 2 `.cid` files introduced; sibling `.md5`/`.sha512` stubs removed.
- Change is data-link metadata only — no source or CMake changes.

</details>

<!--
provenance: claude-code session 2026-04-22 (batch CID migration across ITK remote modules)
-->